### PR TITLE
Working on junctions annotations

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -29,6 +29,8 @@ Note, for proper AltAnalyze functionality, you need to have [samtools](https://f
 ```
 cd tests
 ./unit_tests_in_docker.sh
+./e2e_tests_in_docker.sh
 ./cwl_tests_in_docker.sh
+./wdl_tests_in_docker.sh
 ```
 

--- a/altanalyze3/components/aggregate/main.py
+++ b/altanalyze3/components/aggregate/main.py
@@ -199,7 +199,7 @@ def load_counts_data(query_locations, query_aliases, selected_chr, tmp_location,
         )
         current_df = current_df[current_df.index.get_level_values("chr").isin(selected_chr)]                         # subset only to those chromosomes that are provided in --chr
         counts_df = current_df if counts_df is None else counts_df.join(current_df, how="outer").fillna(0)
-        counts_df = counts_df.astype(pandas.SparseDtype("uint32", 0))                                                # saves memory and is required before exporting to h5ad
+        counts_df = counts_df.astype(pandas.SparseDtype("int32", 0))                                                # saves memory and is required before exporting to h5ad
 
     logging.info("Sorting counts by coordinates in ascending order")
     counts_df.sort_index(ascending=True, inplace=True)

--- a/altanalyze3/components/aggregate/main.py
+++ b/altanalyze3/components/aggregate/main.py
@@ -121,10 +121,11 @@ class RefDeque():
         try:
             self.__set_state(self.__deque.popleft(), safe)
         except IndexError:
-            self.__deque.append(next(self.__reference_iter))
-            self.__set_state(self.__deque.popleft(), safe)
-        except StopIteration:
-            self.__exhausted = True
+            try:
+                self.__deque.append(next(self.__reference_iter))
+                self.__set_state(self.__deque.popleft(), safe)
+            except StopIteration:
+                self.__exhausted = True
 
     def restore(self):
         if len(self.__buffer) > 0 and self.__last_ref is not None:        # restore only when we have what to restore

--- a/altanalyze3/components/aggregate/main.py
+++ b/altanalyze3/components/aggregate/main.py
@@ -194,8 +194,15 @@ def load_counts_data(query_locations, query_aliases, selected_chr, tmp_location,
             query_location,
             usecols = [0, 1, 2, 3, 4, 5],
             names = ["chr", "start", "end", "name", query_alias, "strand"],
-            converters={"chr": lambda_chr_converter},
-            sep="\t",
+            converters = {"chr": lambda_chr_converter},
+            dtype = {
+                "start": "uint32",
+                "end": "uint32",
+                "name": "string",
+                query_alias: "uint32",
+                "strand": "category"
+            },
+            sep="\t"
         )
         current_df.set_index(["chr", "start", "end", "name", "strand"], inplace=True)
         current_df = current_df[current_df.index.get_level_values("chr").isin(selected_chr)]                         # subset only to those chromosomes that are provided in --chr

--- a/altanalyze3/components/aggregate/main.py
+++ b/altanalyze3/components/aggregate/main.py
@@ -262,7 +262,7 @@ def load_counts_data(query_locations, query_aliases, selected_chr, tmp_location,
     return (counts_location, coords_location, starts_location, ends_location)
 
 
-def export_to_anndata(args, jobs, location):
+def collect_results(args, jobs, location):
     collected_annotations_df = None
     for job in jobs:
         logging.info(f"""Loading annotated junctions coordinates from {job.location}""")
@@ -324,7 +324,7 @@ def aggregate(args):
 
     adata_location = args.output.with_suffix(".h5ad")
     logging.info(f"""Exporting aggregated counts to {adata_location}""")
-    export_to_anndata(args, jun_annotation_jobs, adata_location)
+    collect_results(args, jun_annotation_jobs, adata_location)
 
     logging.debug("Removing temporary directory")
     shutil.rmtree(args.tmp)

--- a/altanalyze3/components/aggregate/main.py
+++ b/altanalyze3/components/aggregate/main.py
@@ -297,15 +297,21 @@ def collect_results(args, jobs):
         metadata_columns=["annotation", "strand"]
     )
 
-    if args.tsv:
-        tsv_location = args.output.with_suffix(".tsv")
-        logging.info(f"""Exporting aggregated counts to {tsv_location}""")
+    if args.bed:
+        bed_location = args.output.with_suffix(".bed")
+        logging.info(f"""Exporting annotated coordinates to {bed_location}""")
+        counts_df.reset_index(inplace=True)
+        counts_df.drop(columns=["name"], inplace=True)
+        counts_df.rename(columns={"annotation": "name"}, inplace=True)
+        counts_df["score"] = 0
         counts_df.to_csv(
-            tsv_location,
+            bed_location,
             sep="\t",
-            header=True,
-            index=True
+            header=False,
+            index=False,
+            columns=["chr", "start", "end", "name", "score", "strand"]
         )
+        bed_location = get_indexed_bed(bed_location, keep_original=False, force=True)
 
 
 def aggregate(args):

--- a/altanalyze3/utilities/constants.py
+++ b/altanalyze3/utilities/constants.py
@@ -79,10 +79,10 @@ IntronsParams = {
     "index_col": ["chr", "start", "end", "name", "strand"],
     "converters": {"chr": ChrConverter},
     "dtype": {
-        "start": "uint32",
-        "end": "uint32",
+        "start": "int32",
+        "end": "int32",
         "name": "string",
-        "score": "uint32",
+        "score": "int32",
         "strand": "category"
     },
     "sep": "\t"
@@ -95,10 +95,10 @@ JunctionsParams = {
     "index_col": ["chr", "start", "end", "name"],
     "converters": {"chr": ChrConverter},
     "dtype": {
-        "start": "uint32",
-        "end": "uint32",
+        "start": "int32",
+        "end": "int32",
         "name": "string",
-        "score": "uint32"
+        "score": "int32"
     },
     "sep": "\t"
 }
@@ -116,7 +116,7 @@ ReferencesParams = {
         "gene": "string",
         "strand": "category",
         "exon": "category",
-        "end": "uint32"
+        "end": "int32"
     },
     "sep": "\t"
 }
@@ -127,8 +127,8 @@ AnnotationsParams = {
     "index_col": ["chr", "start", "end", "name"],
     "converters": {"chr": ChrConverter},
     "dtype": {
-        "start": "uint32",
-        "end": "uint32",
+        "start": "int32",
+        "end": "int32",
         "name": "string",
         "annotation": "string",
         "strand": "category"

--- a/altanalyze3/utilities/constants.py
+++ b/altanalyze3/utilities/constants.py
@@ -2,6 +2,9 @@ import enum
 from collections import namedtuple
 
 
+ChrConverter = lambda c: c if c.startswith("chr") else f"chr{c}"
+
+
 MAIN_CRH = [
     "chr1",
     "chr2",
@@ -68,3 +71,67 @@ Annotation = namedtuple(
     "Annotation",
     "gene exon strand position order"
 )
+
+
+IntronsParams = {
+    "usecols": [0, 1, 2, 3, 4, 5],
+    "names": ["chr", "start", "end", "name", "score", "strand"],
+    "index_col": ["chr", "start", "end", "name", "strand"],
+    "converters": {"chr": ChrConverter},
+    "dtype": {
+        "start": "uint32",
+        "end": "uint32",
+        "name": "string",
+        "score": "uint32",
+        "strand": "category"
+    },
+    "sep": "\t"
+}
+
+
+JunctionsParams = {
+    "usecols": [0, 1, 2, 3, 4],
+    "names": ["chr", "start", "end", "name", "score"],
+    "index_col": ["chr", "start", "end", "name"],
+    "converters": {"chr": ChrConverter},
+    "dtype": {
+        "start": "uint32",
+        "end": "uint32",
+        "name": "string",
+        "score": "uint32"
+    },
+    "sep": "\t"
+}
+
+
+ReferencesParams = {
+    "usecols": [0, 1, 2, 3, 4, 5],
+    "names": ["gene", "chr", "strand", "exon", "start", "end"],
+    "index_col": ["chr", "start", "end"],
+    "converters": {
+        "chr": ChrConverter,
+        "start": lambda c: int(c)-1                      # need to make [start, end) intervals
+    },
+    "dtype": {
+        "gene": "string",
+        "strand": "category",
+        "exon": "category",
+        "end": "uint32"
+    },
+    "sep": "\t"
+}
+
+AnnotationsParams = {
+    "usecols": [0, 1, 2, 3, 4, 5],
+    "names": ["chr", "start", "end", "name", "annotation", "strand"],
+    "index_col": ["chr", "start", "end", "name"],
+    "converters": {"chr": ChrConverter},
+    "dtype": {
+        "start": "uint32",
+        "end": "uint32",
+        "name": "string",
+        "annotation": "string",
+        "strand": "category"
+    },
+    "sep": "\t"
+}

--- a/altanalyze3/utilities/constants.py
+++ b/altanalyze3/utilities/constants.py
@@ -67,9 +67,19 @@ IntRetRawData = namedtuple(
 )
 
 
+class AnnMatchCat (enum.IntEnum):
+    EXON_START = enum.auto()
+    EXON_END = enum.auto()
+    EXON_MID = enum.auto()
+    INTRON_MID = enum.auto()
+    CLOSEST = enum.auto()
+    def __str__(self):
+        return self.name
+
+
 Annotation = namedtuple(
     "Annotation",
-    "gene exon strand position order"
+    "gene exon strand position match"
 )
 
 

--- a/altanalyze3/utilities/helpers.py
+++ b/altanalyze3/utilities/helpers.py
@@ -6,9 +6,6 @@ import hashlib
 import pkg_resources
 
 
-lambda_chr_converter = lambda c: c if c.startswith("chr") else f"chr{c}"
-
-
 def get_version():
     """
     Returns current version of the package if it's installed

--- a/altanalyze3/utilities/io.py
+++ b/altanalyze3/utilities/io.py
@@ -87,8 +87,14 @@ def get_indexed_reference(location, selected_chr=None, shift_start_by=None, only
         usecols=[0, 1, 2, 3, 4, 5],
         names=["gene", "chr", "strand", "exon", "start", "end"],
         converters={"chr": lambda_chr_converter},
-        skiprows=1,
-        sep="\t",
+        dtype = {
+            "gene": "string",
+            "strand": "category",
+            "exon": "category",
+            "start": "uint32",
+            "end": "uint32"
+        },
+        sep="\t"
     )
     logging.debug(f"""Loaded {len(references_df.index)} lines""")
 

--- a/altanalyze3/utilities/io.py
+++ b/altanalyze3/utilities/io.py
@@ -7,6 +7,7 @@ from altanalyze3.utilities.constants import (
     ChrConverter,
     ReferencesParams
 )
+from altanalyze3.utilities.helpers import get_tmp_suffix
 
 
 def guard_chr(function):
@@ -83,7 +84,7 @@ def is_bam_indexed(location, threads=None):
         return bam_handler.has_index()
 
 
-def get_indexed_references(location, selected_chr=None, only_introns=None):
+def get_indexed_references(location, tmp_location, selected_chr=None, only_introns=None):
     only_introns = False if only_introns is None else only_introns
 
     logging.info(f"""Loading references from {location}""")
@@ -117,7 +118,7 @@ def get_indexed_references(location, selected_chr=None, only_introns=None):
     )
     references_df.drop(["gene", "exon"], axis=1, inplace=True)                                            # droping unused columns
 
-    target_location = location.with_suffix(".bed")
+    target_location = tmp_location.joinpath(get_tmp_suffix()).with_suffix(".bed")
     logging.info(f"""Saving references as a BED file to {target_location}""")
     references_df.to_csv(
         target_location,

--- a/altanalyze3/utilities/io.py
+++ b/altanalyze3/utilities/io.py
@@ -132,7 +132,7 @@ def export_counts_to_anndata(counts_df, location, counts_columns=None, metadata_
     adata.obs_names = counts_columns
     adata.var_names = counts_df.index.to_frame(index=False).astype(str)[["chr", "start", "end"]].agg("-".join, axis=1)
     if metadata_columns is not None:
-        adata_var = counts_df.copy().loc[:, metadata_columns]
+        adata_var = counts_df.copy().loc[:, metadata_columns].astype(str)
         adata_var.index = adata.var.index.copy()
         adata.var = adata_var
     adata.write(location)

--- a/altanalyze3/utilities/parser.py
+++ b/altanalyze3/utilities/parser.py
@@ -272,6 +272,7 @@ class ArgsParser():
         self.args.strandness = IntRetCat[self.args.strandness.upper()]
         self.args.ref = get_indexed_references(
             location=self.args.ref,
+            tmp_location=self.args.tmp,
             selected_chr=self.args.chr,
             only_introns=True
         )
@@ -300,6 +301,7 @@ class ArgsParser():
                 sys.exit(1)
             self.args.ref = get_indexed_references(
                 location=self.args.ref,
+                tmp_location=self.args.tmp,
                 selected_chr=self.args.chr,
                 only_introns=False
             )

--- a/altanalyze3/utilities/parser.py
+++ b/altanalyze3/utilities/parser.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import pysam
 import logging
@@ -168,26 +169,35 @@ class ArgsParser():
         aggregate_parser.set_defaults(func=aggregate)
         aggregate_parser.add_argument(
             "--juncounts",
-            help="Path the junction counts files. Coordinates are treated as 0-based. Number and order should correspond to --intcounts",
+            help=" ".join(
+                [
+                    "Path the junction counts files. Coordinates are treated as 0-based.",
+                    "If provided with --intcounts, the number and the order should",
+                    "correspond to --intcounts."
+                ]
+            ),
             type=str,
-            nargs="+",
-            required=True   # safety measure
+            nargs="*"
         )
         aggregate_parser.add_argument(
             "--intcounts",
-            help="Path the intron counts files. Coordinates are treated as 0-based. Number and order should correspond to --juncounts",
+            help=" ".join(
+                [
+                    "Path the intron counts files. Coordinates are treated as 0-based.",
+                    "If provided with --juncounts, the number and the order should",
+                    "correspond to --juncounts."
+                ]
+            ),
             type=str,
-            nargs="+",
-            required=True   # safety measure
+            nargs="*"
         )
         aggregate_parser.add_argument(
             "--aliases",
             help=" ".join(
                 [
-                    "Column names to be used for the loaded counts.",
-                    "The number of provided aliases should be equal to the number of",
-                    "--intcounts and --juncounts files."
-                    "Default: rootname of --intcounts files."
+                    "Column names to be used for the loaded counts. The number of provided",
+                    "aliases should be equal to the number of --intcounts and/or --juncounts",
+                    "files. Default: rootname of --intcounts and/or --intcounts files."
                 ]
             ),
             type=str,
@@ -195,9 +205,14 @@ class ArgsParser():
         )
         aggregate_parser.add_argument(
             "--ref",
-            help="Path to the gene model reference file. Coordinates are treated as 1-based.",
+            help=" ".join(
+                [
+                    "Path to the gene model reference file. Coordinates are treated as 1-based.",
+                    "Required if --juncounts parameter was provided."
+                ]
+            ),
             type=str,
-            required=True
+            required=False
         )
         aggregate_parser.add_argument(
             "--chr",
@@ -223,7 +238,7 @@ class ArgsParser():
         selected = [] if selected is None else selected
         normalized_args = {}
         for key, value in self.args.__dict__.items():
-            if key in selected:
+            if key in selected and value is not None:
                 if isinstance(value, list):
                     for v in value:
                         normalized_args.setdefault(key, []).append(
@@ -254,27 +269,40 @@ class ArgsParser():
         pass
 
     def assert_args_for_count_introns(self):
+        self.args.strandness = IntRetCat[self.args.strandness.upper()]
         self.args.ref = get_indexed_references(
             location=self.args.ref,
             selected_chr=self.args.chr,
             only_introns=True
         )
-        self.args.strandness = IntRetCat[self.args.strandness.upper()]
 
     def assert_args_for_aggregate(self):
-        self.args.ref = get_indexed_references(
-            location=self.args.ref,
-            selected_chr=self.args.chr,
-            only_introns=False
-        )
-        if len(self.args.juncounts) != len(self.args.intcounts):
+        if self.args.juncounts is None and self.args.intcounts is None:
+            logging.error("At least one of the --juncounts or --intcounts inputs should be provided")
+            sys.exit(1)
+        if self.args.juncounts is not None and self.args.intcounts is not None and len(self.args.juncounts) != len(self.args.intcounts):
             logging.error("Number of the provided files for --juncounts and --intcounts should be equal")
             sys.exit(1)
+        if self.args.aliases is not None:
+            if self.args.juncounts is not None and len(self.args.aliases) != len(self.args.juncounts):
+                logging.error("Number of the provided --aliases and --juncounts files should be equal")
+                sys.exit(1)
+            if self.args.intcounts is not None and len(self.args.aliases) != len(self.args.intcounts):
+                logging.error("Number of the provided --aliases and --intcounts files should be equal")
+                sys.exit(1)
         if self.args.aliases is None:
-            self.args.aliases = [location.stem for location in self.args.intcounts]
-        elif len(self.args.aliases) != len(self.args.intcounts):
-            logging.error("Number of the provided --aliases and --intcounts/--juncounts should be equal")
-            sys.exit(1)
+            zipped = zip(self.args.juncounts) if self.args.juncounts is not None else zip(self.args.intcounts)
+            zipped = zip(*zip(*zipped), self.args.intcounts if self.args.intcounts is not None else self.args.juncounts)
+            self.args.aliases = [os.path.commonprefix([a.stem, b.stem]) for a, b in zipped]
+        if self.args.juncounts is not None:
+            if self.args.ref is None:
+                logging.error("--ref parameter is required when using with --intcounts")
+                sys.exit(1)
+            self.args.ref = get_indexed_references(
+                location=self.args.ref,
+                selected_chr=self.args.chr,
+                only_introns=False
+            )
 
     def assert_common_args(self):
         self.args.loglevel = getattr(logging, self.args.loglevel.upper())

--- a/altanalyze3/utilities/parser.py
+++ b/altanalyze3/utilities/parser.py
@@ -207,8 +207,8 @@ class ArgsParser():
             default=MAIN_CRH
         )
         aggregate_parser.add_argument(
-            "--tsv",
-            help="Export results as TSV file. Default: False",                                    # mostly for debug purposes
+            "--bed",
+            help="Export annotated coordinates as BED file. Default: False",
             action="store_true"
         )
         self.add_common_arguments(aggregate_parser)

--- a/cwls/tools/altanalyze-aggregate.cwl
+++ b/cwls/tools/altanalyze-aggregate.cwl
@@ -1,0 +1,250 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+
+requirements:
+- class: DockerRequirement
+  dockerPull: altanalyze:latest
+- class: InlineJavascriptRequirement
+  expressionLib:
+  - var get_output_prefix = function(ext) {
+        if (inputs.output_prefix) {
+          return inputs.output_prefix+ext;
+        }
+        return "results"+ext;
+    };
+- class: InitialWorkDirRequirement
+  listing: |
+    ${
+      if (inputs.reference_file != null) {
+        return [
+          {
+            "entry": inputs.reference_file,
+            "entryname": inputs.reference_file.basename,
+            "writable": true
+          }
+        ]
+      } else {
+        return []
+      }
+    }
+
+
+inputs:
+
+  junction_bed_file:
+    type:
+      - "null"
+      - File
+      - type: array
+        items: File
+    inputBinding:
+      prefix: "--juncounts"
+    doc: |
+      Path the junction counts files. Coordinates are treated as 0-based.
+      If provided with --intcounts, the number and the order should
+      correspond to --intcounts.
+
+  intron_bed_file:
+    type:
+      - "null"
+      - File
+      - type: array
+        items: File
+    inputBinding:
+      prefix: "--intcounts"
+    doc: |
+      Path the intron counts files. Coordinates are treated as 0-based.
+      If provided with --juncounts, the number and the order should
+      correspond to --juncounts.
+
+  aliases:
+    type:
+      - "null"
+      - string
+      - type: array
+        items: string
+    inputBinding:
+      prefix: "--aliases"
+    doc: |
+      Column names to be used for the loaded counts. The number of provided aliases
+      should be equal to the number of --intcounts and/or --juncounts files.
+      Default: rootname of --intcounts and/or --intcounts files.
+
+  reference_file:
+    type: File?
+    inputBinding:
+      prefix: "--ref"
+    doc: |
+      Path to the gene model reference file. Coordinates are treated as 1-based.
+      Required if --juncounts parameter was provided.
+
+  chrom_list:
+    type:
+      - "null"
+      - string
+      - type: array
+        items: string
+    inputBinding:
+      prefix: "--chr"
+    doc: |
+      Select chromosomes to process.
+      Default: only main chromosomes
+
+  export_to_bed:
+    type: boolean?
+    inputBinding:
+      prefix: "--bed"
+    doc: |
+      Export annotated coordinates as BED file.
+      Default: False
+
+  log_level:
+    type:
+    - "null"
+    - type: enum
+      symbols:
+      - "fatal"
+      - "error"
+      - "warning"
+      - "info"
+      - "debug"
+    inputBinding:
+      prefix: "--loglevel"
+    doc: |
+      Logging level.
+      Default: info
+
+  threads:
+    type: int?
+    inputBinding:
+      prefix: "--threads"
+    doc: |
+      Number of threads to run in parallel where applicable.
+      Default: 1
+
+  processes:
+    type: int?
+    inputBinding:
+      prefix: "--cpus"
+    doc: |
+      Number of processes to run in parallel where applicable.
+      Default: 1
+
+  output_prefix:
+    type: string?
+    default: ""
+    inputBinding:
+      prefix: "--output"
+      valueFrom: $(get_output_prefix("_agg"))
+    doc: |
+      Output prefix.
+      Default: results
+
+
+outputs:
+
+  aggregated_bed_file:
+    type: File?
+    outputBinding:
+      glob: $(get_output_prefix("_agg.bed.gz"))
+    secondaryFiles:
+    - .tbi
+
+  aggregated_h5ad_file:
+    type: File
+    outputBinding:
+      glob: $(get_output_prefix("_agg.h5ad"))
+
+  stdout_log:
+    type: stdout
+
+  stderr_log:
+    type: stderr
+
+
+baseCommand: ["altanalyze3", "aggregate"]
+
+stdout: $(get_output_prefix("_agg_stdout.log"))
+stderr: $(get_output_prefix("_agg_stderr.log"))
+
+
+$namespaces:
+  s: http://schema.org/
+
+$schemas:
+- https://github.com/schemaorg/schemaorg/raw/main/data/releases/11.01/schemaorg-current-http.rdf
+
+
+label: "AltAnalyze3 Aggregate"
+s:name: "AltAnalyze3 Aggregate"
+s:alternateName: "AltAnalyze3 Aggregate"
+
+s:downloadUrl: https://raw.githubusercontent.com/SalomonisLab/altanalyze3/master/cwls/tools/altanalyze-aggregate.cwl
+s:codeRepository: https://github.com/SalomonisLab/altanalyze3
+s:license: http://www.apache.org/licenses/LICENSE-2.0
+
+s:isPartOf:
+  class: s:CreativeWork
+  s:name: Common Workflow Language
+  s:url: http://commonwl.org/
+
+s:creator:
+- class: s:Organization
+  s:legalName: "Cincinnati Children's Hospital Medical Center"
+  s:location:
+  - class: s:PostalAddress
+    s:addressCountry: "USA"
+    s:addressLocality: "Cincinnati"
+    s:addressRegion: "OH"
+    s:postalCode: "45229"
+    s:streetAddress: "3333 Burnet Ave"
+    s:telephone: "+1(513)636-4200"
+  s:logo: "https://www.cincinnatichildrens.org/-/media/cincinnati%20childrens/global%20shared/childrens-logo-new.png"
+  s:department:
+  - class: s:Organization
+    s:legalName: "Allergy and Immunology"
+    s:department:
+    - class: s:Organization
+      s:legalName: "Barski Research Lab"
+      s:member:
+      - class: s:Person
+        s:name: Michael Kotliar
+        s:email: mailto:misha.kotliar@gmail.com
+        s:sameAs:
+        - id: http://orcid.org/0000-0002-6486-3898
+
+
+doc: |
+  AltAnalyze3 Aggregate
+
+
+s:about: |
+  usage: altanalyze3 aggregate [-h] [--juncounts [JUNCOUNTS [JUNCOUNTS ...]]] [--intcounts [INTCOUNTS [INTCOUNTS ...]]]
+                               [--aliases [ALIASES [ALIASES ...]]] [--ref REF] [--chr [CHR [CHR ...]]] [--bed]
+                               [--loglevel {fatal,error,warning,info,debug}] [--threads THREADS] [--cpus CPUS] [--tmp TMP]
+                               [--output OUTPUT]
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --juncounts [JUNCOUNTS [JUNCOUNTS ...]]
+                          Path the junction counts files. Coordinates are treated as 0-based. If provided with --intcounts,
+                          the number and the order should correspond to --intcounts.
+    --intcounts [INTCOUNTS [INTCOUNTS ...]]
+                          Path the intron counts files. Coordinates are treated as 0-based. If provided with --juncounts,
+                          the number and the order should correspond to --juncounts.
+    --aliases [ALIASES [ALIASES ...]]
+                          Column names to be used for the loaded counts. The number of provided aliases should be equal to
+                          the number of --intcounts and/or --juncounts files.
+                          Default: rootname of --intcounts and/or --intcounts files.
+    --ref REF             Path to the gene model reference file. Coordinates are treated as 1-based. Required if --juncounts
+                          parameter was provided.
+    --chr [CHR [CHR ...]]
+                          Select chromosomes to process. Default: only main chromosomes
+    --bed                 Export annotated coordinates as BED file. Default: False
+    --loglevel {fatal,error,warning,info,debug}
+                          Logging level. Default: info
+    --threads THREADS     Number of threads to run in parallel where applicable. Default: 1
+    --cpus CPUS           Number of processes to run in parallel where applicable. Default: 1
+    --tmp TMP             Temporary files location. Default: tmp
+    --output OUTPUT       Output prefix. Default: results

--- a/cwls/tools/altanalyze-aggregate.cwl
+++ b/cwls/tools/altanalyze-aggregate.cwl
@@ -13,21 +13,6 @@ requirements:
         }
         return "results"+ext;
     };
-- class: InitialWorkDirRequirement
-  listing: |
-    ${
-      if (inputs.reference_file != null) {
-        return [
-          {
-            "entry": inputs.reference_file,
-            "entryname": inputs.reference_file.basename,
-            "writable": true
-          }
-        ]
-      } else {
-        return []
-      }
-    }
 
 
 inputs:

--- a/cwls/tools/altanalyze-intcount.cwl
+++ b/cwls/tools/altanalyze-intcount.cwl
@@ -22,11 +22,6 @@ requirements:
           "entry": inputs.alignment_file,
           "entryname": inputs.alignment_file.basename,
           "writable": true
-        },
-        {
-          "entry": inputs.reference_file,
-          "entryname": inputs.reference_file.basename,
-          "writable": true
         }
       ]
     }

--- a/cwls/workflows/altanalyze-count.cwl
+++ b/cwls/workflows/altanalyze-count.cwl
@@ -105,6 +105,16 @@ outputs:
     outputSource: juncount/junction_bed_file
     doc: "Junction counts BED file"
 
+  aggregated_bed_file:
+    type: File
+    outputSource: aggregate/aggregated_bed_file
+    doc: "Aggergated counts BED file"
+
+  aggregated_h5ad_file:
+    type: File
+    outputSource: aggregate/aggregated_h5ad_file
+    doc: "Aggergated counts H5AD file"
+
   intcount_stdout_log:
     type: File[]
     outputSource: intcount/stdout_log
@@ -124,6 +134,16 @@ outputs:
     type: File[]
     outputSource: juncount/stderr_log
     doc: "Stderr log from juncount step"
+
+  aggregate_stdout_log:
+    type: File
+    outputSource: aggregate/stdout_log
+    doc: "Stdout log from aggregate step"
+
+  aggregate_stderr_log:
+    type: File
+    outputSource: aggregate/stderr_log
+    doc: "Stderr log from aggregate step"
 
 
 steps:
@@ -158,6 +178,24 @@ steps:
     - alignment_file
     out:
     - junction_bed_file
+    - stdout_log
+    - stderr_log
+
+  aggregate:
+    run: ../tools/altanalyze-aggregate.cwl
+    in:
+      junction_bed_file: juncount/junction_bed_file
+      intron_bed_file: intcount/intron_bed_file
+      reference_file: reference_file
+      chrom_list: chrom_list
+      export_to_bed:
+        default: true
+      log_level: log_level
+      threads: threads
+      processes: processes
+    out:
+    - aggregated_bed_file
+    - aggregated_h5ad_file
     - stdout_log
     - stderr_log
 

--- a/tests/cwl_tests/altanalyze-aggregate-1.yaml
+++ b/tests/cwl_tests/altanalyze-aggregate-1.yaml
@@ -1,0 +1,9 @@
+junction_bed_file:
+  class: File
+  location: "../data/controls/Cal27P5_1_juncounts.bed"
+intron_bed_file:
+  class: File
+  location: "../data/controls/Cal27P5_1_intcounts.bed"
+reference_file:
+  class: File
+  location: "../data/gene_model_all.tsv"

--- a/tests/cwl_tests/altanalyze-aggregate-2.yaml
+++ b/tests/cwl_tests/altanalyze-aggregate-2.yaml
@@ -1,0 +1,11 @@
+junction_bed_file:
+  class: File
+  location: "../data/controls/Cal27P5_1_juncounts.bed"
+intron_bed_file:
+  class: File
+  location: "../data/controls/Cal27P5_1_intcounts.bed"
+reference_file:
+  class: File
+  location: "../data/gene_model_all.tsv"
+export_to_bed: true
+output_prefix: "custom"

--- a/tests/cwl_tests/altanalyze-aggregate-3.yaml
+++ b/tests/cwl_tests/altanalyze-aggregate-3.yaml
@@ -1,0 +1,21 @@
+junction_bed_file:
+- class: File
+  location: "../data/controls/Cal27P5_1_juncounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_2_juncounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_3_juncounts.bed"
+intron_bed_file:
+- class: File
+  location: "../data/controls/Cal27P5_1_intcounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_2_intcounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_3_intcounts.bed"
+aliases: ["a", "b", "c"]
+chrom_list: "chr1"
+reference_file:
+  class: File
+  location: "../data/gene_model_all.tsv"
+export_to_bed: true
+output_prefix: "custom"

--- a/tests/cwl_tests/altanalyze-aggregate-4.yaml
+++ b/tests/cwl_tests/altanalyze-aggregate-4.yaml
@@ -1,0 +1,13 @@
+junction_bed_file:
+- class: File
+  location: "../data/controls/Cal27P5_1_juncounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_2_juncounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_3_juncounts.bed"
+chrom_list: "chr1"
+reference_file:
+  class: File
+  location: "../data/gene_model_all.tsv"
+export_to_bed: true
+output_prefix: "custom"

--- a/tests/cwl_tests/altanalyze-aggregate-5.yaml
+++ b/tests/cwl_tests/altanalyze-aggregate-5.yaml
@@ -1,0 +1,10 @@
+intron_bed_file:
+- class: File
+  location: "../data/controls/Cal27P5_1_intcounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_2_intcounts.bed"
+- class: File
+  location: "../data/controls/Cal27P5_3_intcounts.bed"
+chrom_list: "chr1"
+export_to_bed: true
+output_prefix: "custom"

--- a/tests/cwl_tests/conformance_tests.yaml
+++ b/tests/cwl_tests/conformance_tests.yaml
@@ -111,6 +111,100 @@
       location: int_int_stderr.log
 
 # ========================================================
+# altanalyze-aggregate.cwl
+# ========================================================
+
+- job: ./altanalyze-aggregate-1.yaml
+  tool: ../../cwls/tools/altanalyze-aggregate.cwl
+  output:
+    aggregated_bed_file: null
+    aggregated_h5ad_file:
+      class: File
+      location: results_agg.h5ad
+    stdout_log:
+      class: File
+      location: results_agg_stdout.log
+    stderr_log:
+      class: File
+      location: results_agg_stderr.log
+
+- job: ./altanalyze-aggregate-2.yaml
+  tool: ../../cwls/tools/altanalyze-aggregate.cwl
+  output:
+    aggregated_bed_file:
+      class: File
+      location: custom_agg.bed.gz
+      secondaryFiles:
+      - class: File
+        location: custom_agg.bed.gz.tbi
+    aggregated_h5ad_file:
+      class: File
+      location: custom_agg.h5ad
+    stdout_log:
+      class: File
+      location: custom_agg_stdout.log
+    stderr_log:
+      class: File
+      location: custom_agg_stderr.log
+
+- job: ./altanalyze-aggregate-3.yaml
+  tool: ../../cwls/tools/altanalyze-aggregate.cwl
+  output:
+    aggregated_bed_file:
+      class: File
+      location: custom_agg.bed.gz
+      secondaryFiles:
+      - class: File
+        location: custom_agg.bed.gz.tbi
+    aggregated_h5ad_file:
+      class: File
+      location: custom_agg.h5ad
+    stdout_log:
+      class: File
+      location: custom_agg_stdout.log
+    stderr_log:
+      class: File
+      location: custom_agg_stderr.log
+
+- job: ./altanalyze-aggregate-4.yaml
+  tool: ../../cwls/tools/altanalyze-aggregate.cwl
+  output:
+    aggregated_bed_file:
+      class: File
+      location: custom_agg.bed.gz
+      secondaryFiles:
+      - class: File
+        location: custom_agg.bed.gz.tbi
+    aggregated_h5ad_file:
+      class: File
+      location: custom_agg.h5ad
+    stdout_log:
+      class: File
+      location: custom_agg_stdout.log
+    stderr_log:
+      class: File
+      location: custom_agg_stderr.log
+
+- job: ./altanalyze-aggregate-5.yaml
+  tool: ../../cwls/tools/altanalyze-aggregate.cwl
+  output:
+    aggregated_bed_file:
+      class: File
+      location: custom_agg.bed.gz
+      secondaryFiles:
+      - class: File
+        location: custom_agg.bed.gz.tbi
+    aggregated_h5ad_file:
+      class: File
+      location: custom_agg.h5ad
+    stdout_log:
+      class: File
+      location: custom_agg_stdout.log
+    stderr_log:
+      class: File
+      location: custom_agg_stderr.log
+
+# ========================================================
 # altanalyze-count.cwl
 # ========================================================
 
@@ -135,6 +229,21 @@
     juncount_stderr_log:
     - class: File
       location: Cal27P5-1_jun_stderr.log
+    aggregated_bed_file:
+      class: File
+      location: results_agg.bed.gz
+      secondaryFiles:
+      - class: File
+        location: results_agg.bed.gz.tbi
+    aggregated_h5ad_file:
+      class: File
+      location: results_agg.h5ad
+    aggregate_stdout_log:
+      class: File
+      location: results_agg_stdout.log
+    aggregate_stderr_log:
+      class: File
+      location: results_agg_stderr.log
 
 - job: ./altanalyze-count-2.yaml
   tool: ../../cwls/workflows/altanalyze-count.cwl
@@ -169,3 +278,18 @@
       location: Cal27P5-1_jun_stderr.log
     - class: File
       location: Cal27P5-2_jun_stderr.log
+    aggregated_bed_file:
+      class: File
+      location: results_agg.bed.gz
+      secondaryFiles:
+      - class: File
+        location: results_agg.bed.gz.tbi
+    aggregated_h5ad_file:
+      class: File
+      location: results_agg.h5ad
+    aggregate_stdout_log:
+      class: File
+      location: results_agg_stdout.log
+    aggregate_stderr_log:
+      class: File
+      location: results_agg_stderr.log

--- a/tests/data_for_tests.sh
+++ b/tests/data_for_tests.sh
@@ -23,4 +23,10 @@ cp Cal27P5-1.bam Cal27P5-1-copy.bam
 
 mkdir -p controls && cd controls
 wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_1_aggregated_counts.bed.gz -O Cal27P5_1_aggregated_counts.bed.gz
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_1_intcounts.bed -O Cal27P5_1_intcounts.bed
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_1_juncounts.bed -O Cal27P5_1_juncounts.bed
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_2_intcounts.bed -O Cal27P5_2_intcounts.bed
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_2_juncounts.bed -O Cal27P5_2_juncounts.bed
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_3_intcounts.bed -O Cal27P5_3_intcounts.bed
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_3_juncounts.bed -O Cal27P5_3_juncounts.bed
 cd ..

--- a/tests/data_for_tests.sh
+++ b/tests/data_for_tests.sh
@@ -20,3 +20,7 @@ wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/
 wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/Cal27P5-3.bam.bai -O Cal27P5-3.bam.bai
 
 cp Cal27P5-1.bam Cal27P5-1-copy.bam
+
+mkdir -p controls && cd controls
+wget -q --show-progress https://github.com/michael-kotliar/altanalyze3_data/raw/main/data/controls/Cal27P5_1_aggregated_counts.bed.gz -O Cal27P5_1_aggregated_counts.bed.gz
+cd ..

--- a/tests/e2e_tests.sh
+++ b/tests/e2e_tests.sh
@@ -33,8 +33,26 @@ then
    exit 1
 elif [ $DIFF_ERROR -eq 1 ]
 then
-   echo "files are different"
+   echo "Cal27P5_1_aggregated_counts.bed.gz file is not equal to the control one"
    exit 1
 else
    echo "success"
 fi
+
+
+echo "Count junctions reads from Cal27P5-1.bam, Cal27P5-2.bam, and Cal27P5-3.bam"
+altanalyze3 juncount --bam ../Cal27P5-1.bam ../Cal27P5-2.bam ../Cal27P5-3.bam \
+                     --output Cal27P5_1_2_3_juncounts
+
+echo "Count introns reads from Cal27P5-1.bam, Cal27P5-2.bam, and Cal27P5-3.bam"
+altanalyze3 intcount --bam ../Cal27P5-1.bam ../Cal27P5-2.bam ../Cal27P5-3.bam \
+                     --ref ../gene_model_all.tsv \
+                     --output Cal27P5_1_2_3_intcounts \
+
+echo "Aggregating counts from Cal27P5_1_2_3_juncounts.bed and Cal27P5_1_2_3_intcounts.bed"
+altanalyze3 aggregate --juncounts ./Cal27P5_1_2_3_juncounts.bed \
+                      --intcounts ./Cal27P5_1_2_3_intcounts.bed \
+                      --ref ../gene_model_all.tsv \
+                      --bed \
+                      --loglevel info \
+                      --output Cal27P5_1_2_3_aggregated_counts

--- a/tests/e2e_tests.sh
+++ b/tests/e2e_tests.sh
@@ -24,3 +24,17 @@ altanalyze3 aggregate --juncounts ./Cal27P5_1_juncounts.bed \
                       --bed \
                       --loglevel info \
                       --output Cal27P5_1_aggregated_counts
+
+diff Cal27P5_1_aggregated_counts.bed.gz ../controls/Cal27P5_1_aggregated_counts.bed.gz
+DIFF_ERROR=$?
+if [ $DIFF_ERROR -eq 2 ]
+then
+   echo "something wrong with the diff command"
+   exit 1
+elif [ $DIFF_ERROR -eq 1 ]
+then
+   echo "files are different"
+   exit 1
+else
+   echo "success"
+fi

--- a/tests/e2e_tests.sh
+++ b/tests/e2e_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+$DIR/data_for_tests.sh
+
+TMP=$DIR/data/e2e_tmp
+
+mkdir -p $TMP
+cd $TMP
+
+echo "Count junctions reads from Cal27P5-1.bam"
+altanalyze3 juncount --bam ../Cal27P5-1.bam \
+                     --output Cal27P5_1_juncounts
+
+echo "Count introns reads from Cal27P5-1.bam"
+altanalyze3 intcount --bam ../Cal27P5-1.bam \
+                     --ref ../gene_model_all.tsv \
+                     --output Cal27P5_1_intcounts \
+
+echo "Aggregating counts from Cal27P5_juncounts.bed and Cal27P5_intcounts.bed"
+altanalyze3 aggregate --juncounts ./Cal27P5_1_juncounts.bed \
+                      --intcounts ./Cal27P5_1_intcounts.bed \
+                      --ref ../gene_model_all.tsv \
+                      --bed \
+                      --loglevel info \
+                      --output Cal27P5_1_aggregated_counts

--- a/tests/e2e_tests.sh
+++ b/tests/e2e_tests.sh
@@ -40,18 +40,27 @@ else
 fi
 
 
-echo "Count junctions reads from Cal27P5-1.bam, Cal27P5-2.bam, and Cal27P5-3.bam"
-altanalyze3 juncount --bam ../Cal27P5-1.bam ../Cal27P5-2.bam ../Cal27P5-3.bam \
-                     --output Cal27P5_1_2_3_juncounts
+echo "Count junctions reads from Cal27P5-2.bam"
+altanalyze3 juncount --bam ../Cal27P5-2.bam \
+                     --output Cal27P5_2_juncounts
 
-echo "Count introns reads from Cal27P5-1.bam, Cal27P5-2.bam, and Cal27P5-3.bam"
-altanalyze3 intcount --bam ../Cal27P5-1.bam ../Cal27P5-2.bam ../Cal27P5-3.bam \
+echo "Count introns reads from Cal27P5-2.bam"
+altanalyze3 intcount --bam ../Cal27P5-2.bam \
                      --ref ../gene_model_all.tsv \
-                     --output Cal27P5_1_2_3_intcounts \
+                     --output Cal27P5_2_intcounts \
 
-echo "Aggregating counts from Cal27P5_1_2_3_juncounts.bed and Cal27P5_1_2_3_intcounts.bed"
-altanalyze3 aggregate --juncounts ./Cal27P5_1_2_3_juncounts.bed \
-                      --intcounts ./Cal27P5_1_2_3_intcounts.bed \
+echo "Count junctions reads from Cal27P5-3.bam"
+altanalyze3 juncount --bam ../Cal27P5-3.bam \
+                     --output Cal27P5_3_juncounts
+
+echo "Count introns reads from Cal27P5-3.bam"
+altanalyze3 intcount --bam ../Cal27P5-3.bam \
+                     --ref ../gene_model_all.tsv \
+                     --output Cal27P5_3_intcounts \
+
+echo "Aggregating counts from Cal27P5_[1/2/3]_juncounts.bed and Cal27P5_[1/2/3]_intcounts.bed"
+altanalyze3 aggregate --juncounts ./Cal27P5_1_juncounts.bed ./Cal27P5_2_juncounts.bed ./Cal27P5_3_juncounts.bed \
+                      --intcounts ./Cal27P5_1_intcounts.bed ./Cal27P5_2_intcounts.bed ./Cal27P5_3_intcounts.bed \
                       --ref ../gene_model_all.tsv \
                       --bed \
                       --loglevel info \

--- a/tests/e2e_tests.sh
+++ b/tests/e2e_tests.sh
@@ -17,6 +17,24 @@ altanalyze3 intcount --bam ../Cal27P5-1.bam \
                      --ref ../gene_model_all.tsv \
                      --output Cal27P5_1_intcounts \
 
+echo "Count junctions reads from Cal27P5-2.bam"
+altanalyze3 juncount --bam ../Cal27P5-2.bam \
+                     --output Cal27P5_2_juncounts
+
+echo "Count introns reads from Cal27P5-2.bam"
+altanalyze3 intcount --bam ../Cal27P5-2.bam \
+                     --ref ../gene_model_all.tsv \
+                     --output Cal27P5_2_intcounts \
+
+echo "Count junctions reads from Cal27P5-3.bam"
+altanalyze3 juncount --bam ../Cal27P5-3.bam \
+                     --output Cal27P5_3_juncounts
+
+echo "Count introns reads from Cal27P5-3.bam"
+altanalyze3 intcount --bam ../Cal27P5-3.bam \
+                     --ref ../gene_model_all.tsv \
+                     --output Cal27P5_3_intcounts \
+
 echo "Aggregating counts from Cal27P5_juncounts.bed and Cal27P5_intcounts.bed"
 altanalyze3 aggregate --juncounts ./Cal27P5_1_juncounts.bed \
                       --intcounts ./Cal27P5_1_intcounts.bed \
@@ -40,23 +58,7 @@ else
 fi
 
 
-echo "Count junctions reads from Cal27P5-2.bam"
-altanalyze3 juncount --bam ../Cal27P5-2.bam \
-                     --output Cal27P5_2_juncounts
 
-echo "Count introns reads from Cal27P5-2.bam"
-altanalyze3 intcount --bam ../Cal27P5-2.bam \
-                     --ref ../gene_model_all.tsv \
-                     --output Cal27P5_2_intcounts \
-
-echo "Count junctions reads from Cal27P5-3.bam"
-altanalyze3 juncount --bam ../Cal27P5-3.bam \
-                     --output Cal27P5_3_juncounts
-
-echo "Count introns reads from Cal27P5-3.bam"
-altanalyze3 intcount --bam ../Cal27P5-3.bam \
-                     --ref ../gene_model_all.tsv \
-                     --output Cal27P5_3_intcounts \
 
 echo "Aggregating counts from Cal27P5_[1/2/3]_juncounts.bed and Cal27P5_[1/2/3]_intcounts.bed"
 altanalyze3 aggregate --juncounts ./Cal27P5_1_juncounts.bed ./Cal27P5_2_juncounts.bed ./Cal27P5_3_juncounts.bed \

--- a/tests/e2e_tests_in_docker.sh
+++ b/tests/e2e_tests_in_docker.sh
@@ -6,7 +6,7 @@ ALTANALYZE_URL=${4:-`git config --get remote.origin.url`}
 
 WORKING_DIR=$( cd ../"$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-echo "Running unit tests with Python ${PYTHON_VERSION} in dockerized Ubuntu $UBUNTU_VERSION"
+echo "Running e2e tests in dockerized Ubuntu $UBUNTU_VERSION with Python ${PYTHON_VERSION}"
 echo "Using AltAnalyze downloaded from ${ALTANALYZE_URL}, version ${ALTANALYZE_VERSION}"
 echo "Working directory $WORKING_DIR"
 
@@ -20,4 +20,4 @@ docker build --no-cache --build-arg UBUNTU_VERSION=$UBUNTU_VERSION \
 docker run --rm -it -v ${WORKING_DIR}:${WORKING_DIR} \
                     --workdir ${WORKING_DIR}/tests \
                     altanalyze:latest \
-                    ${WORKING_DIR}/tests/unit_tests.sh
+                    ${WORKING_DIR}/tests/e2e_tests.sh

--- a/tests/unit_tests/test_data.py
+++ b/tests/unit_tests/test_data.py
@@ -13,7 +13,13 @@ CONTROL_MD5_SUMS = {
     "Cal27P5-3.bam": "3d6fdef5e90c16deed6c36b418c597c4",
     "Cal27P5-3.bam.bai": "c92fbf32ffcf874979c41051f0d2e16c",
     "Cal27P5-1-copy.bam": "6e418cb604ea82c90d4b3e832afb4997",
-    "Cal27P5_1_aggregated_counts.bed.gz": "26251bd42bac659434799040c8b0caf8"
+    "Cal27P5_1_aggregated_counts.bed.gz": "26251bd42bac659434799040c8b0caf8",
+    "Cal27P5_1_intcounts.bed": "6f5250f1a841438fadcbe1419966f133",
+    "Cal27P5_1_juncounts.bed": "24f6a6ac5f831c7709102c235db03ec5",
+    "Cal27P5_2_intcounts.bed": "2d9889a6520f96012ba7d4be5cdcfea3",
+    "Cal27P5_2_juncounts.bed": "0ab1f2283ba349f9b08dc76d1f29dfe9",
+    "Cal27P5_3_intcounts.bed": "be222bf62519f5b6c601377955e4ef76",
+    "Cal27P5_3_juncounts.bed": "91863b9f8ce7c7d8fc2177b50ef0175e"
 }
 
 

--- a/tests/unit_tests/test_data.py
+++ b/tests/unit_tests/test_data.py
@@ -13,7 +13,7 @@ CONTROL_MD5_SUMS = {
     "Cal27P5-3.bam": "3d6fdef5e90c16deed6c36b418c597c4",
     "Cal27P5-3.bam.bai": "c92fbf32ffcf874979c41051f0d2e16c",
     "Cal27P5-1-copy.bam": "6e418cb604ea82c90d4b3e832afb4997",
-    "Cal27P5_1_aggregated_counts.bed.gz": "0048c9fb8b27fcac933de61ced15fd98"
+    "Cal27P5_1_aggregated_counts.bed.gz": "8299eed6c0f471850d67939f35c576bc"
 }
 
 

--- a/tests/unit_tests/test_data.py
+++ b/tests/unit_tests/test_data.py
@@ -13,7 +13,7 @@ CONTROL_MD5_SUMS = {
     "Cal27P5-3.bam": "3d6fdef5e90c16deed6c36b418c597c4",
     "Cal27P5-3.bam.bai": "c92fbf32ffcf874979c41051f0d2e16c",
     "Cal27P5-1-copy.bam": "6e418cb604ea82c90d4b3e832afb4997",
-    "Cal27P5_1_aggregated_counts.bed.gz": "8299eed6c0f471850d67939f35c576bc"
+    "Cal27P5_1_aggregated_counts.bed.gz": "445b52d8c95b4fc710f41a264563add5"
 }
 
 

--- a/tests/unit_tests/test_data.py
+++ b/tests/unit_tests/test_data.py
@@ -13,7 +13,7 @@ CONTROL_MD5_SUMS = {
     "Cal27P5-3.bam": "3d6fdef5e90c16deed6c36b418c597c4",
     "Cal27P5-3.bam.bai": "c92fbf32ffcf874979c41051f0d2e16c",
     "Cal27P5-1-copy.bam": "6e418cb604ea82c90d4b3e832afb4997",
-    "Cal27P5_1_aggregated_counts.bed.gz": "445b52d8c95b4fc710f41a264563add5"
+    "Cal27P5_1_aggregated_counts.bed.gz": "26251bd42bac659434799040c8b0caf8"
 }
 
 

--- a/tests/unit_tests/test_data.py
+++ b/tests/unit_tests/test_data.py
@@ -13,6 +13,7 @@ CONTROL_MD5_SUMS = {
     "Cal27P5-3.bam": "3d6fdef5e90c16deed6c36b418c597c4",
     "Cal27P5-3.bam.bai": "c92fbf32ffcf874979c41051f0d2e16c",
     "Cal27P5-1-copy.bam": "6e418cb604ea82c90d4b3e832afb4997",
+    "Cal27P5_1_aggregated_counts.bed.gz": "0048c9fb8b27fcac933de61ced15fd98"
 }
 
 

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -33,8 +33,14 @@ DATA_FOLDER = pathlib.Path(__file__).resolve().parents[1].joinpath("data")
         )
     ]
 )
-def test_get_all_ref_chr(location, control_ref_chr):                           # this will also check guard_chr function
-    calculated_ref_chr = get_all_ref_chr(get_indexed_references(DATA_FOLDER.joinpath(location)), 1)
+def test_get_all_ref_chr(tmp_path, location, control_ref_chr):                           # this will also check guard_chr function
+    calculated_ref_chr = get_all_ref_chr(
+        get_indexed_references(
+            DATA_FOLDER.joinpath(location),
+            tmp_path
+        ),
+        1
+    )
     assert sorted(calculated_ref_chr) == sorted(control_ref_chr)
 
 

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -37,7 +37,7 @@ def test_get_all_ref_chr(tmp_path, location, control_ref_chr):                  
     calculated_ref_chr = get_all_ref_chr(
         get_indexed_references(
             DATA_FOLDER.joinpath(location),
-            tmp_path
+            tmp_path                                                                     # https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#tmp-path
         ),
         1
     )

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -5,7 +5,7 @@ from altanalyze3.utilities.io import (
     get_all_ref_chr,
     is_bam_paired,
     is_bam_indexed,
-    get_indexed_reference
+    get_indexed_references
 )
 
 
@@ -34,7 +34,7 @@ DATA_FOLDER = pathlib.Path(__file__).resolve().parents[1].joinpath("data")
     ]
 )
 def test_get_all_ref_chr(location, control_ref_chr):                           # this will also check guard_chr function
-    calculated_ref_chr = get_all_ref_chr(get_indexed_reference(DATA_FOLDER.joinpath(location)), 1)
+    calculated_ref_chr = get_all_ref_chr(get_indexed_references(DATA_FOLDER.joinpath(location)), 1)
     assert sorted(calculated_ref_chr) == sorted(control_ref_chr)
 
 

--- a/tests/wdl_tests.sh
+++ b/tests/wdl_tests.sh
@@ -13,5 +13,6 @@ cd $DIR/wdl_tests
 java -jar /usr/local/bin/cromwell.jar run $DIR/../wdls/altanalyze-intcount.wdl --inputs altanalyze-intcount-1.json --options $TMP_DIR/options.json
 java -jar /usr/local/bin/cromwell.jar run $DIR/../wdls/altanalyze-juncount.wdl --inputs altanalyze-juncount-1.json --options $TMP_DIR/options.json
 java -jar /usr/local/bin/cromwell.jar run $DIR/../wdls/altanalyze-juncount.wdl --inputs altanalyze-juncount-2.json --options $TMP_DIR/options.json
+java -jar /usr/local/bin/cromwell.jar run $DIR/../wdls/altanalyze-aggregate.wdl --inputs altanalyze-aggregate-1.json --options $TMP_DIR/options.json
 rm -rf cromwell-executions cromwell-workflow-logs
 

--- a/tests/wdl_tests/altanalyze-aggregate-1.json
+++ b/tests/wdl_tests/altanalyze-aggregate-1.json
@@ -1,0 +1,13 @@
+{
+    "AggregateWorkflow.junction_bed_file": [
+        "../data/controls/Cal27P5_1_juncounts.bed",
+        "../data/controls/Cal27P5_2_juncounts.bed",
+        "../data/controls/Cal27P5_3_juncounts.bed"
+    ],
+    "AggregateWorkflow.intron_bed_file": [
+        "../data/controls/Cal27P5_1_intcounts.bed",
+        "../data/controls/Cal27P5_2_intcounts.bed",
+        "../data/controls/Cal27P5_3_intcounts.bed"
+    ],
+    "AggregateWorkflow.reference_file": "../data/gene_model_all.tsv"
+}

--- a/wdls/altanalyze-aggregate.wdl
+++ b/wdls/altanalyze-aggregate.wdl
@@ -1,0 +1,62 @@
+version 1.0
+
+workflow AggregateWorkflow {
+    input {
+        Array[File] junction_bed_file
+        Array[File] intron_bed_file
+        File reference_file
+        Int? threads
+        Int? processes
+        String? output_prefix = "results"
+    }
+    call AggregateTask {
+        input:
+        junction_bed_file = junction_bed_file,
+        intron_bed_file = intron_bed_file,
+        reference_file = reference_file,
+        threads = threads,
+        processes = processes,
+        output_prefix = output_prefix
+    }
+    output {
+        File aggregated_bed_file = AggregateTask.aggregated_bed_file
+        File aggregated_bed_tbi_file = AggregateTask.aggregated_bed_tbi_file
+        File aggregated_h5ad_file = AggregateTask.aggregated_h5ad_file
+        File stdout_log = AggregateTask.stdout_log
+        File stderr_log = AggregateTask.stderr_log
+    }
+}
+
+task AggregateTask {
+    input {
+        Array[File] junction_bed_file
+        Array[File] intron_bed_file
+        File reference_file
+        Int? threads
+        Int? processes
+        String? output_prefix
+    }
+    command {
+        altanalyze3 aggregate \
+        --juncounts ${sep=" " junction_bed_file} \
+        --intcounts ${sep=" " intron_bed_file} \
+        --ref ${reference_file} \
+        --bed \
+        ${"--threads " + threads} \
+        ${"--cpus " + processes} \
+        ${"--output " + output_prefix}
+    }
+    output {
+        File aggregated_bed_file = "${output_prefix}.bed.gz"
+        File aggregated_bed_tbi_file = "${output_prefix}.bed.gz.tbi"
+        File aggregated_h5ad_file = "${output_prefix}.h5ad"
+        File stdout_log = stdout()
+        File stderr_log = stderr()
+    }
+    runtime {
+        docker: "altanalyze:latest"
+    }
+    meta {
+        author: "Michael Kotliar"
+    }
+}


### PR DESCRIPTION
Juncounts and intcounts files are processed separately. First, we load all juncount files and JOIN them by coordinates (SQL type of JOIN), so at the end, we have only unique chr:start-end regions. These coordinates are then saved into the sorted indexed BED file. Technicaly, we save three files - one with the correct coordinated and two with only start and only end coordinates. We need these two additional files to easily iterate over the sorted start and end coordinates separately, but we still want to be able use BED format for that. Aggregated counts are saved separately in the python pickled format as they will be loaded after annotation assignment.

Then we separately try to annotate all junction start and all junction end coordinates. For that we first iterate over the sorted indexed gene model BED file and sorted indexed junction start BED file. For each start coordinate we identify the region from the gene model that includes this coordinate and save it in a form of `Annotation` named tuple. In addition to the gene, exon, and strand, we also save the match type which can be one of the `AnnMatchCat` enum class and `position` that won't be 0 only when the match type is one of `EXON_MID`, `INTRON_MID`, or `CLOSEST`.  `CLOSEST` is the specific type of match for those cases when the junction coordinate is at the beginning or at the end of the chromosome and didn't overlap any of the known from gene model file regions. The same procedure is done for the junction end coordinates. Note, that multiple annotations can be assigned to the same start or end junction coordinate as certain genes may have overlapping regions.

Then, once we collected all annotations from our junction start and end coordinates, we iterate over all junctions and try to find the best annotation for each of them. If we have multiple annotations for junction start and junctions end we iterate over the product of them and choose the best. The logic of choosing the best annotation is implemented in the `GroupedAnnotations` class. Briefly, we try to find all exact, partial and distant matches. We call distant all the matches when junction start and end coordinates belong to the different genes. The best annotation is either the first found exact match, or the first found partial match, or the first found distant match, depending of what kind of matched were found.

Once we assigned all junctions annotations, we load intcounts which are already annotated and do the same type of JOIN as we did for the juncounts. However, we don't need to assign any annotation for them. Loaded intcounts and annotated juncounts are then merged into one big list of regions sorted by coordinates. The results are then saved into the h5ad and BED files (in the BED file we save only coordinates and annotations to be visualized in IGV)

```python
class AnnMatchCat (enum.IntEnum):
    EXON_START = enum.auto()
    EXON_END = enum.auto()
    EXON_MID = enum.auto()
    INTRON_MID = enum.auto()
    CLOSEST = enum.auto()
    def __str__(self):
        return self.name

Annotation = namedtuple(
    "Annotation",
    "gene exon strand position match"
)
```
