### PR TITLE
Flip coordinates based on strand when exporting to h5ad

### DIFF
--- a/altanalyze3/components/aggregate/main.py
+++ b/altanalyze3/components/aggregate/main.py
@@ -355,6 +355,7 @@ def collect_results(args):
         counts_df=counts_df,
         location=adata_location,
         counts_columns=[c for c in counts_df.columns.values if c not in metadata_columns],
+        strand_coords=True,
         metadata_columns=metadata_columns
     )
 


### PR DESCRIPTION
When exporting to h5ad file if the strand is "-" the junction name will be saved as "chr:end-start". Otherwise, "chr:start-end"